### PR TITLE
Conversion raw to g work

### DIFF
--- a/drivers/kionix/kx132-1211/kx132-conversions.c
+++ b/drivers/kionix/kx132-1211/kx132-conversions.c
@@ -92,5 +92,20 @@ float reading_in_g(const unsigned int reading_in_dec_counts,
         reading *= ACCELERATION_OF_GRAVITY_AT_EARTH_MEAN_SURFACE;
     }
 
+    switch (desired_units)
+    {
+        case: KX132_READING_CONV__ACCELERATION_IN_G
+            break;
+        case: KX132_READING_CONV__ACCELERATION_IN_M_PER_S_SQUARED
+            reading *= ACCELERATION_OF_GRAVITY_AT_EARTH_MEAN_SURFACE;
+            break;
+        case: KX132_READING_CONV__ACCELERATION_IN_INCHES_PER_S_SQUARED
+            reading *= ACCELERATION_OF_GRAVITY_AT_EARTH_MEAN_SURFACE_IN_INCHES_PER_SEC_SQUARED;
+            break;
+
+        default:
+            break;
+    }
+
     return reading;
 }

--- a/drivers/kionix/kx132-1211/kx132-conversions.c
+++ b/drivers/kionix/kx132-1211/kx132-conversions.c
@@ -23,9 +23,6 @@ float reading_in_g(const unsigned int reading_in_dec_counts,
     float units_of_g_range_min = 0.0;
     float reading = 0.0;
 
-printk("\n---\n--- KX132 driver:  got raw acceleration reading of %u, range enum value %u ---\n",
-  reading_in_dec_counts, range);
-
 // For 16-bit, high resolution readings:
     {
 // NEED to consider bounds check on reading to keep within unsigned 0x0000 to 0xFFFF, 16-bit range of values.
@@ -81,12 +78,14 @@ printk("\n---\n--- KX132 driver:  got raw acceleration reading of %u, range enum
                 )
               );
 
+#if 0
     printk("(1) range max minus range min = %3.3f\n", (units_of_g_range_max - units_of_g_range_min));
     printk("(2) decimal count max = %6.1f\n", raw_reading_count_max);
     printk("(3) decimal count min = %6.1f\n", raw_reading_count_min);
     printk("(4) decimal count = %6.1f\n", (raw_reading_count_max - raw_reading_count_min));
     printk("desired standard units enum value = %u\n", desired_units);
     printk("quotient of (1) over (4) = %3.8f\n", ((units_of_g_range_max - units_of_g_range_min) / (raw_reading_count_max - raw_reading_count_min)));
+#endif
 
     if ( desired_units == ACCELERATION_IN_M_PER_S_SQUARED )
     {

--- a/drivers/kionix/kx132-1211/kx132-conversions.c
+++ b/drivers/kionix/kx132-1211/kx132-conversions.c
@@ -89,12 +89,12 @@ float reading_in_g(const unsigned int reading_in_dec_counts,
 
     switch (desired_units)
     {
-        case: KX132_READING_CONV__ACCELERATION_IN_G
+        case KX132_READING_CONV__ACCELERATION_IN_G:
             break;
-        case: KX132_READING_CONV__ACCELERATION_IN_M_PER_S_SQUARED
+        case KX132_READING_CONV__ACCELERATION_IN_M_PER_S_SQUARED:
             reading *= ACCELERATION_OF_GRAVITY_AT_EARTH_MEAN_SURFACE;
             break;
-        case: KX132_READING_CONV__ACCELERATION_IN_INCHES_PER_S_SQUARED
+        case KX132_READING_CONV__ACCELERATION_IN_INCHES_PER_S_SQUARED:
             reading *= ACCELERATION_OF_GRAVITY_AT_EARTH_MEAN_SURFACE_IN_INCHES_PER_SEC_SQUARED;
             break;
 

--- a/drivers/kionix/kx132-1211/kx132-conversions.c
+++ b/drivers/kionix/kx132-1211/kx132-conversions.c
@@ -87,11 +87,6 @@ float reading_in_g(const unsigned int reading_in_dec_counts,
     printk("quotient of (1) over (4) = %3.8f\n", ((units_of_g_range_max - units_of_g_range_min) / (raw_reading_count_max - raw_reading_count_min)));
 #endif
 
-    if ( desired_units == ACCELERATION_IN_M_PER_S_SQUARED )
-    {
-        reading *= ACCELERATION_OF_GRAVITY_AT_EARTH_MEAN_SURFACE;
-    }
-
     switch (desired_units)
     {
         case: KX132_READING_CONV__ACCELERATION_IN_G

--- a/drivers/kionix/kx132-1211/kx132-conversions.h
+++ b/drivers/kionix/kx132-1211/kx132-conversions.h
@@ -37,15 +37,19 @@
 
 enum acceleration_units_of_measure
 {
-    ACCELERATION_IN_M_PER_S_SQUARED,
-    ACCELERATION_IN_INCHES_PER_S_SQUARED
+    KX132_READING_CONV__ACCELERATION_IN_G,
+    KX132_READING_CONV__ACCELERATION_IN_M_PER_S_SQUARED,
+    KX132_READING_CONV__ACCELERATION_IN_INCHES_PER_S_SQUARED
 };
 
 // https://en.wikipedia.org/wiki/Gravitational_acceleration
 // https://en.wikipedia.org/wiki/Standard_gravity
 #define ACCELERATION_OF_GRAVITY_AT_EARTH_MEAN_SURFACE 9.8067
 
-
+// 39.37007874 inches per meter
+// 386.0905511795/s^2 equals 1 g.
+// 386.08858267717 per http://conversion.org/acceleration/standard-gravity/inches-per-second-squared
+#define ACCELERATION_OF_GRAVITY_AT_EARTH_MEAN_SURFACE_IN_INCHES_PER_SEC_SQUARED 386.08858267717
 
 float reading_in_g(const unsigned int reading_in_dec_counts,
                    const enum kx132_acceleration_resolutions resolution,

--- a/drivers/kionix/kx132-1211/kx132-registers.c
+++ b/drivers/kionix/kx132-1211/kx132-registers.c
@@ -746,11 +746,6 @@ int kx132_get_attr__acc_reading_in_standard_units(const struct device *dev, stru
 
     union converted_reading_union_t reading;
     reading.as_float = reading_in_g(raw_acc_reading, resolution, range, desired_units);
-
-    // 0.046200979501 . . . should appear as 0x3d3d3d3d when printed as hex format integer
-    // reading.as_float = 0.046200979501;
-printk("- KX132 driver - registers.c got back converted reading value %3.6f g\n", reading.as_float);
-
     value->val1 = reading.as_int;
 
     return 0;


### PR DESCRIPTION
Pulling in modest refinement and a correction to KX132 readings conversions.  Noting obvious thing that units of g and units of meters per second squared are distinct units, the former 'g' being scaled by the approximate value 9.80665.  Also tested inclusion of this out-of-tree driver in a Zephyr application which does not instantiate a physical sensor.  This means there is no Zephyr start-up code generated to initialize a KX132 device' driver structures, and hence there is no set of `sensor_attr_set()`, `sensor_attr_get()` nor the Zephyr sensor API fetch routines.  There can however still be calls made from application code to public facing functions in the driver.  Recently added source file kx132-conversions.c provides one such function, and that's the one we tested in this way.